### PR TITLE
feat: adding coverage path as an optional input in charm-tiobe-scan

### DIFF
--- a/.github/workflows/charm-tiobe-scan.yaml
+++ b/.github/workflows/charm-tiobe-scan.yaml
@@ -16,6 +16,11 @@ on:
         default: ""
         required: false
         type: string
+      coverage-folder:
+        description: "Folder under which the coverage xml report exists."
+        default: "cover"
+        required: false
+        type: string
 
 jobs:
   scan:
@@ -39,10 +44,11 @@ jobs:
       - name: Generate unittest coverage report
         env:
           CHARM_PATH: ${{ inputs.charm-path }}
+          COVERAGE_FOLDER: ${{ inputs.coverage-folder }}
         run: |
           base_wd="$(pwd)"
           cd "${CHARM_PATH}"
-          tox -e unit && coverage xml -o "${base_wd}/cover/cobertura.xml"
+          tox -e unit && coverage xml -o "${base_wd}/${COVERAGE_FOLDER}/cobertura.xml"
 
       - name: Activate and prepare Python virtual environment
         env:


### PR DESCRIPTION
Different teams have different folders which tiobe expects the coverage to be in. 

This PR introduces a new coverage folder input to make it customizable for other teams/repos.